### PR TITLE
Upgrading GitHub Actions to latest version

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 5.0.x
       - name: Install dotnet format
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 5.0.x
       - name: Authenticate nuget
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 5.0.x
 


### PR DESCRIPTION
This fixes (🤞) the hanging tests during CI pipeline.

The specific fix is upgrading the checkout action.
My verification involved having a failing branch build, pushing a commit that allowed the tests to pass, then reverting that commit and seeing the CI pipeline fail again. Pushing the commit again made the tests pass again.