### PR TITLE
Dispose instance of class implementing IDisposable during tests

### DIFF
--- a/HousingRepairsOnlineApi.Tests/GatewaysTests/AddressGatewayTests.cs
+++ b/HousingRepairsOnlineApi.Tests/GatewaysTests/AddressGatewayTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace HousingRepairsOnlineApi.Tests.GatewaysTests
 {
-    public class AddressGatewayTests
+    public class AddressGatewayTests : IDisposable
     {
         private const string authenticationIdentifier = "super secret";
         private const string AddressApiEndpoint = "https://our-porxy-UH.api";
@@ -90,5 +90,9 @@ namespace HousingRepairsOnlineApi.Tests.GatewaysTests
             Assert.Empty(data);
         }
 
+        public void Dispose()
+        {
+            mockHttp.Dispose();
+        }
     }
 }

--- a/HousingRepairsOnlineApi.Tests/GatewaysTests/AppointmentGatewayTests.cs
+++ b/HousingRepairsOnlineApi.Tests/GatewaysTests/AppointmentGatewayTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace HousingRepairsOnlineApi.Tests.GatewaysTests
 {
-    public class AppointmentGatewayTests
+    public class AppointmentGatewayTests : IDisposable
     {
         private readonly AppointmentsGateway systemUnderTest;
         private readonly MockHttpMessageHandler mockHttp;
@@ -117,6 +117,11 @@ namespace HousingRepairsOnlineApi.Tests.GatewaysTests
             // Assert
             await act.Should().NotThrowAsync<Exception>();
             mockHttp.VerifyNoOutstandingExpectation();
+        }
+
+        public void Dispose()
+        {
+            mockHttp.Dispose();
         }
     }
 }


### PR DESCRIPTION
This may be a factor of hanging tests within the CI pipeline (this [comment](https://github.com/xunit/xunit/issues/1169#issuecomment-782089069) suggests a similar fix worked elsewhere).