### PR TITLE
Add communal repair type

### DIFF
--- a/HousingRepairsOnlineApi.Tests/ControllersTests/AppointmentsControllerTests.cs
+++ b/HousingRepairsOnlineApi.Tests/ControllersTests/AppointmentsControllerTests.cs
@@ -46,6 +46,19 @@ namespace HousingRepairsOnlineApi.Tests.ControllersTests
         }
 
         [Fact]
+        public async Task TestCommunalEndpoint()
+        {
+            // Arrange
+
+            // Act
+            _ = await systemUndertest.AvailableCommunalAppointments(RepairLocation, RepairProblem, RepairIssue, LocationId);
+
+            // Assert
+            availableAppointmentsUseCaseMock.Verify(
+                x => x.Execute(RepairType.Communal, RepairLocation, RepairProblem, RepairIssue, LocationId, null), Times.Once);
+        }
+
+        [Fact]
         public async Task GivenAFromDate_WhenRequestingAvailableAppointments_ThenResultsAreReturned()
         {
             // Arrange

--- a/HousingRepairsOnlineApi.Tests/ControllersTests/RepairRequestsControllerTests.cs
+++ b/HousingRepairsOnlineApi.Tests/ControllersTests/RepairRequestsControllerTests.cs
@@ -73,6 +73,22 @@ namespace HousingRepairsOnlineApi.Tests
             saveRepairRequestUseCaseMock.Verify(x => x.Execute(RepairType.Tenant, repairRequest), Times.Once);
         }
 
+        [Fact]
+        public async Task TestCommunalEndpoint()
+        {
+            // Arrange
+            var (repairRequest, repair) = CreateRepairRequestAndRepair();
+
+            saveRepairRequestUseCaseMock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<RepairRequest>())).ReturnsAsync(repair);
+
+            // Act
+            var result = await systemUnderTest.CommunalRepair(repairRequest);
+
+            // Assert
+            GetStatusCode(result).Should().Be(200);
+            saveRepairRequestUseCaseMock.Verify(x => x.Execute(RepairType.Communal, repairRequest), Times.Once);
+        }
+
         private (RepairRequest, Repair) CreateRepairRequestAndRepair()
         {
             var repairRequest = new RepairRequest

--- a/HousingRepairsOnlineApi.Tests/ControllersTests/RepairTriageControllerTests.cs
+++ b/HousingRepairsOnlineApi.Tests/ControllersTests/RepairTriageControllerTests.cs
@@ -52,6 +52,20 @@ namespace HousingRepairsOnlineApi.Tests.ControllersTests
                 x => x.Execute(RepairType.Tenant, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
+        [Fact]
+        public async Task TestCommunalEndpoint()
+        {
+            // Arrange
+
+            // Act
+            var result = await systemUnderTest.CommunalRepairTriageOptions(emergencyArgument, notEligibleNonEmergencyArgument, unableToBookArgument, contactUsArgument);
+
+            // Assert
+            GetStatusCode(result).Should().Be(200);
+            retrieveTriageJourneyOptionsMock.Verify(
+                x => x.Execute(RepairType.Communal, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
         [Theory]
         [MemberData(nameof(InvalidParameterValueData))]
         public async Task

--- a/HousingRepairsOnlineApi/Controllers/AppointmentsController.cs
+++ b/HousingRepairsOnlineApi/Controllers/AppointmentsController.cs
@@ -30,6 +30,18 @@ namespace HousingRepairsOnlineApi.Controllers
             return await AvailableAppointments(RepairType.Tenant, repairLocation, repairProblem, repairIssue, locationId, fromDate);
         }
 
+        [HttpGet]
+        [Route("AvailableCommunalAppointments")]
+        public async Task<IActionResult> AvailableCommunalAppointments(
+            [FromQuery] string repairLocation,
+            [FromQuery] string repairProblem,
+            [FromQuery] string repairIssue,
+            [FromQuery] string locationId,
+            [FromQuery] DateTime? fromDate = null)
+        {
+            return await AvailableAppointments(RepairType.Communal, repairLocation, repairProblem, repairIssue, locationId, fromDate);
+        }
+
         internal async Task<IActionResult> AvailableAppointments(string repairType,
             string repairLocation,
             string repairProblem,

--- a/HousingRepairsOnlineApi/Controllers/RepairController.cs
+++ b/HousingRepairsOnlineApi/Controllers/RepairController.cs
@@ -37,6 +37,13 @@ namespace HousingRepairsOnlineApi.Controllers
             return await SaveRepair(RepairType.Tenant, repairRequest);
         }
 
+        [HttpPost]
+        [Route("CommunalRepair")]
+        public async Task<IActionResult> CommunalRepair([FromBody] RepairRequest repairRequest)
+        {
+            return await SaveRepair(RepairType.Communal, repairRequest);
+        }
+
         internal async Task<IActionResult> SaveRepair(string repairType, RepairRequest repairRequest)
         {
             try

--- a/HousingRepairsOnlineApi/Controllers/RepairTriageController.cs
+++ b/HousingRepairsOnlineApi/Controllers/RepairTriageController.cs
@@ -26,6 +26,14 @@ namespace HousingRepairsOnlineApi.Controllers
             return await JourneyRepairTriageOptions(RepairType.Tenant, contactUsValue, emergencyValue, notEligibleNonEmergencyValue, unableToBookValue);
         }
 
+        [HttpGet]
+        [Route("CommunalRepairTriageOptions")]
+        public async Task<IActionResult> CommunalRepairTriageOptions(string emergencyValue,
+            string notEligibleNonEmergencyValue, string unableToBookValue, string contactUsValue)
+        {
+            return await JourneyRepairTriageOptions(RepairType.Communal, contactUsValue, emergencyValue, notEligibleNonEmergencyValue, unableToBookValue);
+        }
+
         internal async Task<IActionResult> JourneyRepairTriageOptions(string repairType, string emergencyValue,
             string notEligibleNonEmergencyValue, string unableToBookValue, string contactUsValue)
         {

--- a/HousingRepairsOnlineApi/Helpers/RepairType.cs
+++ b/HousingRepairsOnlineApi/Helpers/RepairType.cs
@@ -8,7 +8,9 @@ public static class RepairType
 {
     public const string Tenant = "TENANT";
 
-    public static readonly IEnumerable<string> All = new[] { Tenant };
+    public const string Communal = "COMMUNAL";
+
+    public static readonly IEnumerable<string> All = new[] { Tenant, Communal };
 
     public static Func<string, bool> IsValidValue = repairType => All.Contains(repairType);
 }


### PR DESCRIPTION
This PR adds communal repair type and the endpoints (which interact with the SOR engine), but not the implementation yet.

Once this is merged, each communal area can be worked on separately.