### PR TITLE
Update configuration name to differentiate between different repair types

### DIFF
--- a/terraform/key_vault.tf
+++ b/terraform/key_vault.tf
@@ -119,7 +119,7 @@ resource "azurerm_key_vault_secret" "scheduling-api-url-staging" {
 }
 
 resource "azurerm_key_vault_secret" "sor-configuration-tenant-staging" {
-  name         = "sor-configuration-staging"
+  name         = "sor-configuration-tenant-staging"
   value        = var.sor_configuration_tenant_staging
   key_vault_id = azurerm_key_vault.hro-repairs-api-key-vault.id
 }
@@ -194,7 +194,7 @@ resource "azurerm_key_vault_secret" "scheduling-api-url-production" {
 }
 
 resource "azurerm_key_vault_secret" "sor-configuration-tenant-production" {
-  name         = "sor-configuration-production"
+  name         = "sor-configuration-tenant-production"
   value        = var.sor_configuration_tenant_production
   key_vault_id = azurerm_key_vault.hro-repairs-api-key-vault.id
 }


### PR DESCRIPTION
Missed this in my previous PR (#27).

Doesn't break anything, but should be updated to use representative Azure secret name