### PR TITLE
Add leasehold notification configuration provider

### DIFF
--- a/HousingRepairsOnlineApi.Tests/HelpersTests/NotificationConfiguration/LeaseholdNotificationConfigurationProviderTests.cs
+++ b/HousingRepairsOnlineApi.Tests/HelpersTests/NotificationConfiguration/LeaseholdNotificationConfigurationProviderTests.cs
@@ -1,0 +1,280 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using HousingRepairsOnlineApi.Domain;
+using HousingRepairsOnlineApi.Helpers;
+using HousingRepairsOnlineApi.Helpers.NotificationConfiguration;
+using HousingRepairsOnlineApi.UseCases;
+using Moq;
+using Xunit;
+
+namespace HousingRepairsOnlineApi.Tests.HelpersTests.NotificationConfiguration
+{
+    public class LeaseholdNotificationConfigurationProviderTests
+    {
+        private readonly Mock<IRetrieveImageLinkUseCase> retrieveImageLinkUseCase;
+        private readonly LeaseholdNotificationConfigurationProvider systemUnderTest;
+
+        private readonly string confirmationSmsTemplateId = "confirmationSmsTemplateId";
+        private readonly string confirmationEmailTemplateId = "confirmationEmailTemplateId";
+        private readonly string internalEmailTemplateId = "internalEmailTemplateId";
+        private readonly string imageLink = "imagelink";
+
+        private Repair repair = new()
+        {
+            Id = "id",
+            RepairType = null,
+            Postcode = null,
+            SOR = "SOR",
+            Priority = null,
+            Address = new RepairAddress
+            {
+                LocationId = "12345",
+                Display = "display"
+            },
+            Location = null,
+            Problem = null,
+            Issue = null,
+            ContactPersonNumber = null,
+            Description = new RepairDescription
+            {
+                Text = "description",
+                PhotoUrl = "photourl/photo"
+            },
+            ContactDetails = new RepairContactDetails
+            {
+                Type = AppointmentConfirmationSendingTypes.Email,
+                Value = "abc@defg.hij"
+            },
+            Time = new RepairAvailability()
+            {
+                Display = "some time"
+            }
+        };
+
+        public LeaseholdNotificationConfigurationProviderTests()
+        {
+            retrieveImageLinkUseCase = new Mock<IRetrieveImageLinkUseCase>();
+            retrieveImageLinkUseCase.Setup(x => x.Execute(It.IsAny<string>())).Returns(imageLink);
+
+            systemUnderTest = new LeaseholdNotificationConfigurationProvider(confirmationSmsTemplateId, confirmationEmailTemplateId, internalEmailTemplateId);
+        }
+
+        [Fact]
+        public void GivenTemplateIds_WhenGet_ThenCorrectTemplateIdsReturned()
+        {
+            //Assert
+            Assert.True(systemUnderTest.ConfirmationEmailTemplateId == confirmationEmailTemplateId);
+            Assert.True(systemUnderTest.ConfirmationSmsTemplateId == confirmationSmsTemplateId);
+            Assert.True(systemUnderTest.InternalEmailTemplateId == internalEmailTemplateId);
+        }
+
+        //Arrange
+        public static IEnumerable<object[]> InvalidStringArgumentTestData()
+        {
+            yield return new object[] { new ArgumentNullException(), null };
+            yield return new object[] { new ArgumentException(), "" };
+            yield return new object[] { new ArgumentException(), " " };
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public void GivenAnInvalidBookingRef_WhenGetPersonalisationForEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            this.repair.Id = invalidStr;
+            //Act
+            Action act = () => systemUnderTest.GetPersonalisationForEmailTemplate(repair);
+
+            //Assert
+            act.Should().ThrowExactly<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public void GivenAnInvalidTime_WhenGetPersonalisationForEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            repair.Time.Display = invalidStr;
+            //Act
+            Action act = () => systemUnderTest.GetPersonalisationForEmailTemplate(repair);
+
+            //Assert
+            act.Should().ThrowExactly<T>();
+        }
+
+        [Fact]
+        public void GivenValidRepairValues_WhenGetPersonalisationForEmailTemplate_ThenCorrectDictionaryIsReturned()
+        {
+            //Arrange
+            Dictionary<string, dynamic> personalisation = new()
+            {
+                {"repair_ref", repair.Id},
+                {"appointment_time", repair.Time.Display}
+            };
+            //Act
+            var act = systemUnderTest.GetPersonalisationForEmailTemplate(repair);
+            //Assert
+            act.Should().BeEquivalentTo(personalisation);
+        }
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public void GivenAnInvalidBookingRef_WhenGetPersonalisationForSMSTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            this.repair.Id = invalidStr;
+            //Act
+            Action act = () => systemUnderTest.GetPersonalisationForSmsTemplate(repair);
+
+            //Assert
+            act.Should().ThrowExactly<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public void GivenAnInvalidTime_WhenGetPersonalisationForSMSTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            repair.Time.Display = invalidStr;
+            //Act
+            Action act = () => systemUnderTest.GetPersonalisationForSmsTemplate(repair);
+
+            //Assert
+            act.Should().ThrowExactly<T>();
+        }
+
+        [Fact]
+        public void GivenValidRepairValues_WhenGetPersonalisationForSMSTemplate_ThenCorrectDictionaryIsReturned()
+        {
+            //Arrange
+            Dictionary<string, dynamic> personalisation = new()
+            {
+                {"repair_ref", repair.Id},
+                {"appointment_time", repair.Time.Display}
+            };
+            //Act
+            var act = systemUnderTest.GetPersonalisationForSmsTemplate(repair);
+            //Assert
+            act.Should().BeEquivalentTo(personalisation);
+        }
+
+        [Fact]
+        public void GivenNullPhotoURL_WhenGetPersonalisationForInternalEmailTemplate_ThenDefaultIsReturned()
+        {
+            //Arrange
+            repair.Description.PhotoUrl = string.Empty;
+            //Act
+            var act = systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+            //Assert
+            Assert.Equal(act.Result["image_1"], "None");
+        }
+
+        [Fact]
+        public void GivenPhotoURL_WhenGetPersonalisationForInternalEmailTemplate_ThenImageLinkIsReturned()
+        {
+            //Act
+            var act = systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+            //Assert
+            Assert.Equal(act.Result["image_1"], imageLink);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidId_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.Id = invalidStr;
+
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidAddressLocationId_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.Address.LocationId = invalidStr;
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidDisplayAddress_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.Address.Display = invalidStr;
+
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidSor_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.SOR = invalidStr;
+
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidDescriptionText_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.Description.Text = invalidStr;
+
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStringArgumentTestData))]
+#pragma warning disable xUnit1026
+        public async void GivenAnInvalidContactDetailsValue_WhenGetPersonalisationForInternalEmailTemplate_ThenExceptionIsThrown<T>(T exception, string invalidStr) where T : Exception
+#pragma warning restore xUnit1026
+        {
+            // Arrange
+            repair.ContactDetails.Value = invalidStr;
+
+            // Act
+            var act = async () => await systemUnderTest.GetPersonalisationForInternalEmailTemplate(repair, retrieveImageLinkUseCase.Object);
+
+            // Assert
+            await act.Should().ThrowExactlyAsync<T>();
+        }
+    }
+}

--- a/HousingRepairsOnlineApi/Helpers/NotificationConfiguration/LeaseholdNotificationConfigurationProvider.cs
+++ b/HousingRepairsOnlineApi/Helpers/NotificationConfiguration/LeaseholdNotificationConfigurationProvider.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Ardalis.GuardClauses;
+using HousingRepairsOnlineApi.Domain;
+using HousingRepairsOnlineApi.UseCases;
+
+namespace HousingRepairsOnlineApi.Helpers.NotificationConfiguration;
+
+public class LeaseholdNotificationConfigurationProvider : BaseNotificationConfigurationProvider, INotificationConfigurationProvider
+{
+    public LeaseholdNotificationConfigurationProvider(string confirmationSmsTemplateId, string confirmationEmailTemplateId,
+        string internalEmailTemplateId) : base(confirmationSmsTemplateId, confirmationEmailTemplateId,
+        internalEmailTemplateId)
+    {
+    }
+
+    public async Task<IDictionary<string, dynamic>> GetPersonalisationForInternalEmailTemplate(Repair repair, IRetrieveImageLinkUseCase retrieveImageLinkUseCase)
+    {
+        Guard.Against.NullOrWhiteSpace(repair.Id, nameof(repair.Id), "The repair reference provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.Address.LocationId, nameof(repair.Address.LocationId), "The uprn provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.Address.Display, nameof(repair.Address.Display), "The address provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.SOR, nameof(repair.SOR), "The sor provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.Description.Text, nameof(repair.Description.Text), "The repairDescription provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.ContactDetails?.Value, nameof(repair.ContactDetails.Value), "The contact number provided is invalid");
+        var imageLink = await repair.GetImageLink(retrieveImageLinkUseCase);
+
+        return new Dictionary<string, dynamic>
+        {
+            {"repair_ref", repair.Id},
+            {"uprn", repair.Address.LocationId},
+            {"address", repair.Address.Display},
+            {"sor", repair.SOR},
+            {"repair_desc", repair.Description.Text},
+            {"contact_no", repair.ContactDetails?.Value},
+            {"image_1", imageLink}
+        };
+    }
+
+    public IDictionary<string, dynamic> GetPersonalisationForEmailTemplate(Repair repair)
+    {
+        Guard.Against.NullOrWhiteSpace(repair.Id, nameof(repair.Id), "The booking reference provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.Time.Display, nameof(repair.Time.Display), "The appointment time provided is invalid");
+
+        return new Dictionary<string, dynamic>
+        {
+            {"repair_ref", repair.Id},
+            {"appointment_time", repair.Time.Display}
+        };
+    }
+
+    public IDictionary<string, dynamic> GetPersonalisationForSmsTemplate(Repair repair)
+    {
+        Guard.Against.NullOrWhiteSpace(repair.Id, nameof(repair.Id), "The booking reference provided is invalid");
+        Guard.Against.NullOrWhiteSpace(repair.Time.Display, nameof(repair.Time.Display), "The appointment time provided is invalid");
+
+        return new Dictionary<string, dynamic>
+        {
+            {"repair_ref", repair.Id},
+            {"appointment_time", repair.Time.Display}
+        };
+    }
+}

--- a/HousingRepairsOnlineApi/Startup.cs
+++ b/HousingRepairsOnlineApi/Startup.cs
@@ -51,8 +51,16 @@ namespace HousingRepairsOnlineApi
                 EnvironmentVariableHelper.GetEnvironmentVariable("COMMUNAL_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID"),
                 EnvironmentVariableHelper.GetEnvironmentVariable("COMMUNAL_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID"));
 
-            var sendNotificationDictionary = new Dictionary<string, INotificationConfigurationProvider> { { RepairType.Tenant, sendTenantNotification } ,
-                { RepairType.Communal, sendCommunalNotification }};
+            var sendLeaseholdNotification = new LeaseholdNotificationConfigurationProvider(EnvironmentVariableHelper.GetEnvironmentVariable("LEASEHOLD_CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID"),
+                EnvironmentVariableHelper.GetEnvironmentVariable("LEASEHOLD_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID"),
+                EnvironmentVariableHelper.GetEnvironmentVariable("LEASEHOLD_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID"));
+
+            var sendNotificationDictionary = new Dictionary<string, INotificationConfigurationProvider>
+            {
+                { RepairType.Tenant, sendTenantNotification },
+                { RepairType.Communal, sendCommunalNotification },
+                { RepairType.Leasehold, sendLeaseholdNotification },
+            };
 
             services.AddTransient<IDictionary<string, INotificationConfigurationProvider>>(_ => sendNotificationDictionary);
 


### PR DESCRIPTION
This PR should not be merged until the respective leasehold notification templates have been created in Gov Notify and the respective repo secrets update with the template IDs.

Additional work would be required only if the personalisation items in the templates change.